### PR TITLE
feat: Add configurable attempts and continue button

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,23 @@
               </div>
             </div>
           </div>
+          <!-- Number of Attempts Setting -->
+          <div class="accordion-item">
+            <h2 class="accordion-header">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#maxAttemptsCollapse" aria-expanded="false" aria-controls="maxAttemptsCollapse">
+                <i class="bi bi-arrow-repeat me-2"></i>Number of Attempts
+              </button>
+            </h2>
+            <div id="maxAttemptsCollapse" class="accordion-collapse collapse" data-bs-parent="#advancedSettings">
+              <div class="accordion-body">
+                <div class="mb-3">
+                  <label for="maxAttemptsInput" class="form-label">Number of attempts for the agent:</label>
+                  <input type="number" class="form-control" id="maxAttemptsInput" name="maxAttempts" value="5">
+                  <div class="form-text">Set the initial number of turns the agent will run.</div>
+                </div>
+              </div>
+            </div>
+          </div>
           <div class="accordion-item">
             <h2 class="accordion-header">
               <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#tokenCollapse" aria-expanded="false" aria-controls="tokenCollapse">
@@ -166,6 +183,7 @@
     </form>
 
     <div id="results" class="mx-auto my-3 narrative"></div>
+    <button id="continueButton" class="btn btn-secondary mt-2 mx-auto narrative d-none">Continue (1 more turn)</button>
     <div id="status" class="alert alert-info mx-auto my-3 narrative d-none" role="alert"></div>
 
     <footer style="height: 50vh"></footer>


### PR DESCRIPTION
This commit introduces two main enhancements:

1.  **Configurable Number of Attempts:**
    *   Adds an input field in "Advanced Settings" allowing you to define the initial number of attempts (`n`) I make.
    *   The application defaults to 5 attempts if not specified.
    *   My core processing loop now respects this value you define.

2.  **"Continue" Button Functionality:**
    *   After the initial `n` attempts, if the task is not yet complete, a "Continue (1 more turn)" button appears.
    *   Clicking this button allows you to have me make one additional attempt.
    *   The button reappears if the task remains incomplete after the additional attempt, allowing for further incremental continuations.

The implementation involved:
*   Adding a new input field in `index.html`.
*   Modifying `script.js` to read the new setting.
*   Refactoring the main processing loop in `script.js` into a reusable `performAttempt` function.
*   Adding the "Continue" button to `index.html` and implementing its logic in `script.js`, including managing its visibility and state.