### PR TITLE
Fix OpenRouter key link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ API Agent is an interactive web application that allows users to query APIs thro
   - [Jira Token](https://id.atlassian.com/manage-profile/security/api-tokens)
   - [Google Custom Search API Key](https://developers.google.com/custom-search/v1/introduction)
   - [SerpApi Key](https://serpapi.com/manage-api-key)
-  - [OpenRouter API Key](https://openrouter.ai/account/api-keys)
+  - [OpenRouter API Key](https://openrouter.ai/settings/keys)
 
 ### Local Setup
 

--- a/config.js
+++ b/config.js
@@ -291,7 +291,7 @@ Single entity responses return the object directly.
     ],
     token: {
       label: "OpenRouter API key",
-      link: "https://openrouter.ai/account/api-keys",
+      link: "https://openrouter.ai/settings/keys",
       required: true,
       key: "openrouter",
     },


### PR DESCRIPTION
## Summary
- update README instructions for obtaining an OpenRouter API key
- update the token link in `config.js`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b048936c832ca41b5588f8857a7e