### PR TITLE
Add flexible API parameters

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ export const demos = [
     icon: "github",
     title: "GitHub API",
     description: "Query GitHub repositories, users, issues, and more.",
-    prompt: "Use GitHub API. Only if tokens.github is not empty, add Authorization: Bearer ${tokens.github}",
+    prompt: "Use GitHub API. Only if params.github is not empty, add Authorization: Bearer ${params.github}",
     questions: [
       "What are the most starred JavaScript repositories on GitHub?",
       "What did @simonw do in the last few days?",
@@ -12,19 +12,22 @@ export const demos = [
       "List the open issues in the React repository",
       "Show me the most recent pull requests in the Vue.js project",
     ],
-    token: {
-      label: "GitHub API token",
-      link: "https://github.com/settings/tokens",
-      required: false,
-      key: "github",
-    },
+    params: [
+      {
+        label: "GitHub API token",
+        link: "https://github.com/settings/tokens",
+        required: false,
+        key: "github",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "stack-overflow",
     title: "StackOverflow API",
     description: "Search questions, answers, and users on StackOverflow.",
     prompt:
-      "Use StackExchange API. Only if tokens.stackoverflow is not empty, add Authorization: Bearer ${tokens.stackoverflow}",
+      "Use StackExchange API. Only if params.stackoverflow is not empty, add Authorization: Bearer ${params.stackoverflow}",
     questions: [
       "What are the most upvoted JavaScript questions on StackOverflow?",
       "What are the most recent questions about React on StackOverflow?",
@@ -32,35 +35,47 @@ export const demos = [
       "What are the most viewed TypeScript questions this month?",
       "Who are the top users for the React tag on StackOverflow?",
     ],
-    token: {
-      label: "StackOverflow API token",
-      link: "https://stackapps.com/apps/oauth/register",
-      required: false,
-      key: "stackoverflow",
-    },
+    params: [
+      {
+        label: "StackOverflow API token",
+        link: "https://stackapps.com/apps/oauth/register",
+        required: false,
+        key: "stackoverflow",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "graph-up-arrow",
     title: "Google Analytics",
     description: "Explore your website traffic and user behavior with Google Analytics.",
-    prompt: "Use Google Analytics Data API. Send Authorization: Bearer ${tokens.ga}",
+    prompt: "Use Google Analytics Data API. Send Authorization: Bearer ${params.ga}",
     questions: [
       "How many daily active users has your Android app had in the last week?",
       "How many page views the top 10 pages on your site had in the last 28 days?",
       "How many sessions the top 10 pages on your site had in the last 28 days?",
     ],
-    token: {
-      label: "Google Analytics API token",
-      link: "https://developers.google.com/oauthplayground/",
-      required: true,
-      key: "ga",
-    },
+    params: [
+      {
+        label: "Google Analytics API token",
+        link: "https://developers.google.com/oauthplayground/",
+        required: true,
+        key: "ga",
+        type: "password",
+      },
+      {
+        label: "Google Analytics property ID",
+        key: "gaPropertyId",
+        type: "text",
+        required: false,
+      },
+    ],
   },
   {
     icon: "google",
     title: "Google Workspace",
     description: "Access Gmail, Calendar and Drive using Google APIs.",
-    prompt: "Use Google Workspace APIs. Send Authorization: Bearer ${tokens.google}. Max 5 concurrent requests.",
+    prompt: "Use Google Workspace APIs. Send Authorization: Bearer ${params.google}. Max 5 concurrent requests.",
     questions: [
       "List my unread Gmail messages in the inbox",
       "What events do I have tomorrow?",
@@ -68,20 +83,23 @@ export const demos = [
       "What are the largest emails that I can delete?",
       "Create a lunch meeting tomorrow at 12 noon for 30 minutes",
     ],
-    token: {
-      label: "Google OAuth token",
-      link: "https://developers.google.com/oauthplayground/",
-      required: true,
-      key: "google",
-      oauth: {
-        provider: "google",
-        // root.node@gmail.com | Project: Personal mail etc. OAuth Client: Web apps
-        // https://console.cloud.google.com/auth/clients/872568319651-r1jl15a1oektabjl48ch3v9dhipkpdjh.apps.googleusercontent.com?inv=1&invt=AbzTOQ&project=encoded-ensign-221
-        clientId: "872568319651-r1jl15a1oektabjl48ch3v9dhipkpdjh.apps.googleusercontent.com",
-        scope:
-          "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/drive.readonly",
+    params: [
+      {
+        label: "Google OAuth token",
+        link: "https://developers.google.com/oauthplayground/",
+        required: true,
+        key: "google",
+        type: "password",
+        oauth: {
+          provider: "google",
+          // root.node@gmail.com | Project: Personal mail etc. OAuth Client: Web apps
+          // https://console.cloud.google.com/auth/clients/872568319651-r1jl15a1oektabjl48ch3v9dhipkpdjh.apps.googleusercontent.com?inv=1&invt=AbzTOQ&project=encoded-ensign-221
+          clientId: "872568319651-r1jl15a1oektabjl48ch3v9dhipkpdjh.apps.googleusercontent.com",
+          scope:
+            "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/drive.readonly",
+        },
       },
-    },
+    ],
   },
   {
     icon: "book",
@@ -220,19 +238,22 @@ Single entity responses return the object directly.
       "Identify journals that published more than 50 articles on 'artificial intelligence' in 2023 and have a 2-year mean citedness (impact factor) greater than 5.",
       "What percentage of works published by Elsevier (identify via CrossRef member ID) in 2023 are Gold Open Access according to OpenAlex?",
     ],
-    token: {
-      label: "Crossref API token",
-      link: "https://crossref.org/for-developers/",
-      required: false,
-      key: "crossref",
-    },
+    params: [
+      {
+        label: "Crossref API token",
+        link: "https://crossref.org/for-developers/",
+        required: false,
+        key: "crossref",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "kanban",
     title: "JIRA API",
     description: "Query JIRA issues, projects, and workflows.",
     prompt:
-      "Use the Atlassian JIRA REST API. Format JQL queries correctly and use the appropriate endpoints. Send Authorization: Bearer ${tokens.jira}",
+      "Use the Atlassian JIRA REST API. Format JQL queries correctly and use the appropriate endpoints. Send Authorization: Bearer ${params.jira}",
     questions: [
       "List all open bugs in project XYZ",
       "Show me the issues assigned to me",
@@ -240,66 +261,78 @@ Single entity responses return the object directly.
       "Find all critical issues in the backlog",
       "Show the workflow history for issue PROJ-123",
     ],
-    token: {
-      label: "JIRA API token",
-      link: "https://id.atlassian.com/manage-profile/security/api-tokens",
-      required: true,
-      key: "jira",
-    },
+    params: [
+      {
+        label: "JIRA API token",
+        link: "https://id.atlassian.com/manage-profile/security/api-tokens",
+        required: true,
+        key: "jira",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "search",
     title: "Google Custom Search",
     description: "Search the web with a Custom Search Engine.",
     prompt:
-      "Use Google Custom Search JSON API at https://www.googleapis.com/customsearch/v1. Send key=${tokens.cse} and your cx ID along with q, num and other params. Results come in items[] with title, link and snippet.",
+      "Use Google Custom Search JSON API at https://www.googleapis.com/customsearch/v1. Send key=${params.cse} and your cx ID along with q, num and other params. Results come in items[] with title, link and snippet.",
     questions: [
       "Search the web for tutorials on the Fetch API",
       "Find recent news about AI policy",
       "Show images of the Eiffel Tower",
     ],
-    token: {
-      label: "Google CSE API key",
-      link: "https://developers.google.com/custom-search/v1/introduction",
-      required: true,
-      key: "cse",
-    },
+    params: [
+      {
+        label: "Google CSE API key",
+        link: "https://developers.google.com/custom-search/v1/introduction",
+        required: true,
+        key: "cse",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "search-heart",
     title: "SerpApi",
     description: "Retrieve Google search results from SerpApi.",
     prompt:
-      "Use https://serpapi.com/search.json with engine=google, q and api_key=${tokens.serpapi}. Optional params like location, num or start control the results. Parse organic_results[].",
+      "Use https://serpapi.com/search.json with engine=google, q and api_key=${params.serpapi}. Optional params like location, num or start control the results. Parse organic_results[].",
     questions: [
       "Top Google results for best programming laptop 2024",
       "Latest news about OpenAI stock",
       "Find coffee shops in New York",
     ],
-    token: {
-      label: "SerpApi key",
-      link: "https://serpapi.com/manage-api-key",
-      required: true,
-      key: "serpapi",
-    },
+    params: [
+      {
+        label: "SerpApi key",
+        link: "https://serpapi.com/manage-api-key",
+        required: true,
+        key: "serpapi",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "router",
     title: "OpenRouter",
     description: "Call models via the OpenRouter API.",
     prompt:
-      "Use POST https://openrouter.ai/api/v1/chat/completions with Authorization: Bearer ${tokens.openrouter}. Include Referer and X-Title headers. Choose the model parameter to pick a provider.",
+      "Use POST https://openrouter.ai/api/v1/chat/completions with Authorization: Bearer ${params.openrouter}. Include Referer and X-Title headers. Choose the model parameter to pick a provider.",
     questions: [
       "Summarize https://example.com",
       "Explain quantum computing in simple terms",
       "Translate Good morning to French",
     ],
-    token: {
-      label: "OpenRouter API key",
-      link: "https://openrouter.ai/settings/keys",
-      required: true,
-      key: "openrouter",
-    },
+    params: [
+      {
+        label: "OpenRouter API key",
+        link: "https://openrouter.ai/settings/keys",
+        required: true,
+        key: "openrouter",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "globe2",
@@ -312,12 +345,15 @@ Single entity responses return the object directly.
       "Give the intro for Python (programming language)",
       "List sections of the New York City page",
     ],
-    token: {
-      label: "Wikipedia API token",
-      link: "https://www.mediawiki.org/wiki/API:Main_page",
-      required: false,
-      key: "wikipedia",
-    },
+    params: [
+      {
+        label: "Wikipedia API token",
+        link: "https://www.mediawiki.org/wiki/API:Main_page",
+        required: false,
+        key: "wikipedia",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "database",
@@ -326,26 +362,55 @@ Single entity responses return the object directly.
     prompt:
       "Use https://www.wikidata.org/w/api.php. Search via action=wbsearchentities&search=<term>&language=en and fetch details with action=wbgetentities&ids=<id>. No auth needed.",
     questions: ["Find the Wikidata ID for Elon Musk", "Get the birth date of Q42", "List properties of Q90"],
-    token: {
-      label: "Wikidata API token",
-      link: "https://www.wikidata.org/wiki/Wikidata:Data_access",
-      required: false,
-      key: "wikidata",
-    },
+    params: [
+      {
+        label: "Wikidata API token",
+        link: "https://www.wikidata.org/wiki/Wikidata:Data_access",
+        required: false,
+        key: "wikidata",
+        type: "password",
+      },
+    ],
   },
   {
     icon: "film",
     title: "TMDB",
     description: "Discover movies and TV shows with The Movie Database.",
     prompt:
-      "Use https://api.themoviedb.org/3. Send Authorization: Bearer ${tokens.tmdb}. Search via /search/movie?query=<term> and get details from /movie/<id>.",
+      "Use https://api.themoviedb.org/3. Send Authorization: Bearer ${params.tmdb}. Search via /search/movie?query=<term> and get details from /movie/<id>.",
     questions: ["Popular movies this week", "Search for movies about space", "Details for the movie Inception"],
-    token: {
-      label: "TMDB API key",
-      link: "https://www.themoviedb.org/settings/api",
-      required: true,
-      key: "tmdb",
-    },
+    params: [
+      {
+        label: "TMDB API key",
+        link: "https://www.themoviedb.org/settings/api",
+        required: true,
+        key: "tmdb",
+        type: "password",
+      },
+    ],
+  },
+  {
+    icon: "h-circle",
+    title: "HubSpot API",
+    description: "Manage contacts and deals with HubSpot.",
+    prompt:
+      "Use HubSpot API. Send Authorization: Bearer ${params.hubspotToken}. Use hapikey=${params.hubspotClientId} when required.",
+    questions: ["List contacts created last week", "Show total deals amount by stage"],
+    params: [
+      {
+        label: "HubSpot API token",
+        link: "https://developers.hubspot.com/docs/api/overview",
+        required: true,
+        key: "hubspotToken",
+        type: "password",
+      },
+      {
+        label: "HubSpot client ID",
+        key: "hubspotClientId",
+        type: "text",
+        required: false,
+      },
+    ],
   },
 ];
 
@@ -379,7 +444,7 @@ export async function run(params) {
 }
 \`\`\`
 
-The user will ALWAYS call \`result = await run({tokens})\` where \`tokens\` is an object with keys for each API and share the result (or error).
+The user will ALWAYS call \`result = await run({params})\` where `params` is an object with keys for each API and share the result (or error).
 
 Do NOT forget to wrap in \`\`\`js ... \`\`\`
 

--- a/config.js
+++ b/config.js
@@ -49,7 +49,7 @@ export const demos = [
     icon: "graph-up-arrow",
     title: "Google Analytics",
     description: "Explore your website traffic and user behavior with Google Analytics.",
-    prompt: "Use Google Analytics Data API. Send Authorization: Bearer ${params.ga}",
+    prompt: "Use Google Analytics Data API for property ${params.gaPropertyId}. Authorization: Bearer ${params.ga}",
     questions: [
       "How many daily active users has your Android app had in the last week?",
       "How many page views the top 10 pages on your site had in the last 28 days?",
@@ -394,7 +394,7 @@ Single entity responses return the object directly.
     title: "HubSpot API",
     description: "Manage contacts and deals with HubSpot.",
     prompt:
-      "Use HubSpot API. Send Authorization: Bearer ${params.hubspotToken}. Use hapikey=${params.hubspotClientId} when required.",
+      "Use HubSpot API. Send Authorization: Bearer ${params.hubspotToken}. hapikey=${params.hubspotClientId}",
     questions: ["List contacts created last week", "Show total deals amount by stage"],
     params: [
       {
@@ -444,7 +444,7 @@ export async function run(params) {
 }
 \`\`\`
 
-The user will ALWAYS call \`result = await run({params})\` where `params` is an object with keys for each API and share the result (or error).
+The user will ALWAYS call \`result = await run({params})\` where \`params\` is an object with keys for each API and share the result (or error).
 
 Do NOT forget to wrap in \`\`\`js ... \`\`\`
 

--- a/index.html
+++ b/index.html
@@ -147,11 +147,11 @@
           </div>
           <div class="accordion-item">
             <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#tokenCollapse" aria-expanded="false" aria-controls="tokenCollapse">
+              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#tokenCollapse" aria-expanded="true" aria-controls="tokenCollapse">
                 <i class="bi bi-key me-2"></i>API Tokens
               </button>
             </h2>
-            <div id="tokenCollapse" class="accordion-collapse collapse" data-bs-parent="#tokenAccordion">
+            <div id="tokenCollapse" class="accordion-collapse collapse show" data-bs-parent="#tokenAccordion">
               <div class="accordion-body" id="token-inputs">
                 <!-- Token inputs will be dynamically inserted here -->
               </div>

--- a/script.js
+++ b/script.js
@@ -45,12 +45,7 @@ function renderApiCards() {
               <i class="bi bi-${demo.icon} fs-1 mb-3"></i>
               <h5 class="card-title">${demo.title}</h5>
               <p class="card-text">${demo.description}</p>
-              <button
-                class="btn btn-outline-primary select-api"
-                data-index="${index}"
-              >
-                Select
-              </button>
+              <button class="btn btn-outline-primary select-api" data-index="${index}">Select</button>
             </div>
           </div>
         </div>
@@ -88,12 +83,7 @@ function updateSelection() {
       .flatMap((api) => api.questions)
       .map(
         (q) =>
-          html`<button
-            type="button"
-            class="list-group-item list-group-item-action example-question"
-          >
-            ${q}
-          </button>`,
+          html`<button type="button" class="list-group-item list-group-item-action example-question">${q}</button>`,
       ),
     $exampleQuestions,
   );
@@ -101,23 +91,28 @@ function updateSelection() {
   render(
     apis.flatMap((api) =>
       api.params.map(
-        (p) => html`<div class="mb-2">
-          <label for="param-${p.key}" class="form-label d-flex justify-content-between">
-            <span>${p.label}${p.required ? html`<span class="text-danger">*</span>` : ""}</span>
-            ${p.oauth
-              ? html`<button type="button" class="btn btn-sm btn-outline-primary" id="oauth-button-${p.key}">Sign in</button>`
-              : p.link
-                ? html`<a href="${p.link}" target="_blank" rel="noopener">Get token <i class="bi bi-box-arrow-up-right"></i></a>`
-                : ""}
-          </label>
-          <input
-            type="${p.type || "text"}"
-            class="form-control"
-            id="param-${p.key}"
-            placeholder="Enter ${p.label}"
-            ${p.required ? "required" : ""}
-          />
-        </div>`,
+        (p) =>
+          html`<div class="mb-2">
+            <label for="param-${p.key}" class="form-label d-flex justify-content-between">
+              <span>${p.label}${p.required ? html`<span class="text-danger">*</span>` : ""}</span>
+              ${p.oauth
+                ? html`<button type="button" class="btn btn-sm btn-outline-primary" id="oauth-button-${p.key}">
+                    Sign in
+                  </button>`
+                : p.link
+                  ? html`<a href="${p.link}" target="_blank" rel="noopener"
+                      >Get token <i class="bi bi-box-arrow-up-right"></i
+                    ></a>`
+                  : ""}
+            </label>
+            <input
+              type="${p.type || "text"}"
+              class="form-control"
+              id="param-${p.key}"
+              placeholder="Enter ${p.label}"
+              ${p.required ? "required" : ""}
+            />
+          </div>`,
       ),
     ),
     $tokenInputs,
@@ -169,10 +164,7 @@ $exampleQuestions.addEventListener("click", (e) => {
 });
 
 globalThis.customFetch = function (url, ...args) {
-  render(
-    html`Fetching <a href="${url}" target="_blank" rel="noopener">${url}</a>`,
-    $status,
-  );
+  render(html`Fetching <a href="${url}" target="_blank" rel="noopener">${url}</a>`, $status);
   $status.classList.remove("d-none");
   return fetch(url, ...args);
 };
@@ -205,10 +197,7 @@ $taskForm.addEventListener("submit", async (e) => {
         body: JSON.stringify({
           model,
           stream: true,
-          messages: [
-            { role: "system", content: agentPrompt($systemPrompt.value) },
-            ...llmMessages,
-          ],
+          messages: [{ role: "system", content: agentPrompt($systemPrompt.value) }, ...llmMessages],
         }),
       })) {
         message.content = event.content ?? "";
@@ -248,10 +237,7 @@ $taskForm.addEventListener("submit", async (e) => {
     })(message.content);
     let module;
     try {
-      const blob = new Blob(
-        [`const fetch = globalThis.customFetch;\n${code}`],
-        { type: "text/javascript" },
-      );
+      const blob = new Blob([`const fetch = globalThis.customFetch;\n${code}`], { type: "text/javascript" });
       module = await import(URL.createObjectURL(blob));
     } catch (error) {
       messages.push({ role: "user", name: "error", content: error.stack });
@@ -276,11 +262,7 @@ $taskForm.addEventListener("submit", async (e) => {
     $status.classList.add("d-none");
     renderSteps(messages);
 
-    const validationMessages = [
-      ...messages.filter((m) => m.name === "user"),
-      messages.at(-2),
-      messages.at(-1),
-    ];
+    const validationMessages = [...messages.filter((m) => m.name === "user"), messages.at(-2), messages.at(-1)];
     let validationMessage = {
       role: "assistant",
       name: "validator",
@@ -292,10 +274,7 @@ $taskForm.addEventListener("submit", async (e) => {
       body: JSON.stringify({
         model,
         stream: true,
-        messages: [
-          { role: "system", content: validatorPrompt },
-          ...validationMessages,
-        ],
+        messages: [{ role: "system", content: validatorPrompt }, ...validationMessages],
       }),
     })) {
       validationMessage.content = event.content ?? "";
@@ -334,16 +313,11 @@ function renderSteps(steps) {
     steps.map(({ name, content }, i) => {
       const stepNum = i + 1;
       let markdown =
-        name == "result"
-          ? "```json\n" + content + "\n```"
-          : name == "error"
-            ? "```\n" + content + "\n```"
-            : content;
+        name == "result" ? "```json\n" + content + "\n```" : name == "error" ? "```\n" + content + "\n```" : content;
       return html`
         <div class="card mb-3">
           <div
-            class="card-header ${colorMap[name] ||
-            "bg-secondary"} text-white d-flex align-items-center"
+            class="card-header ${colorMap[name] || "bg-secondary"} text-white d-flex align-items-center"
             data-bs-toggle="collapse"
             data-bs-target="#step-${stepNum}"
             role="button"
@@ -355,9 +329,7 @@ function renderSteps(steps) {
             <i class="bi bi-chevron-down ms-auto"></i>
           </div>
           <div class="collapse show" id="step-${stepNum}">
-            <div class="card-body">
-              ${unsafeHTML(marked.parse(markdown ?? ""))}
-            </div>
+            <div class="card-body">${unsafeHTML(marked.parse(markdown ?? ""))}</div>
           </div>
         </div>
       `;

--- a/script.js
+++ b/script.js
@@ -179,10 +179,7 @@ $taskForm.addEventListener("submit", async (e) => {
   const apiKey = document.getElementById("apiKeyInput").value;
   const model = document.getElementById("model").value;
   const attempts = document.getElementById("attempts").value;
-  const request = {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-  };
+  const request = { method: "POST", headers: { "Content-Type": "application/json" } };
   if (apiKey) request.headers["Authorization"] = `Bearer ${apiKey}`;
   else request.credentials = "include";
 
@@ -201,12 +198,7 @@ $taskForm.addEventListener("submit", async (e) => {
         }),
       })) {
         message.content = event.content ?? "";
-        if (event.error)
-          messages.push({
-            role: "user",
-            name: "error",
-            content: JSON.stringify(event),
-          });
+        if (event.error) messages.push({ role: "user", name: "error", content: JSON.stringify(event) });
         renderSteps(messages);
         if (event.error) return;
       }
@@ -226,11 +218,7 @@ $taskForm.addEventListener("submit", async (e) => {
       try {
         return [...content.matchAll(/```js(.*?)```/gs)][0].at(-1);
       } catch (error) {
-        messages.push({
-          role: "user",
-          name: "error",
-          content: "No JS code block to run",
-        });
+        messages.push({ role: "user", name: "error", content: "No JS code block to run" });
         renderSteps(messages);
         return;
       }
@@ -263,11 +251,7 @@ $taskForm.addEventListener("submit", async (e) => {
     renderSteps(messages);
 
     const validationMessages = [...messages.filter((m) => m.name === "user"), messages.at(-2), messages.at(-1)];
-    let validationMessage = {
-      role: "assistant",
-      name: "validator",
-      content: "",
-    };
+    let validationMessage = { role: "assistant", name: "validator", content: "" };
     messages.push(validationMessage);
     for await (const event of asyncLLM(`${baseUrl}/chat/completions`, {
       ...request,
@@ -278,12 +262,7 @@ $taskForm.addEventListener("submit", async (e) => {
       }),
     })) {
       validationMessage.content = event.content ?? "";
-      if (event.error)
-        messages.push({
-          role: "user",
-          name: "error",
-          content: JSON.stringify(event),
-        });
+      if (event.error) messages.push({ role: "user", name: "error", content: JSON.stringify(event) });
       renderSteps(messages);
       if (event.error) return;
     }

--- a/script.js
+++ b/script.js
@@ -253,7 +253,7 @@ $taskForm.addEventListener("submit", async (e) => {
       });
     });
     try {
-      const result = await module.run({ params });
+      const result = await module.run(params);
       messages.at(-1).content = JSON.stringify(result, null, 2);
     } catch (error) {
       messages.at(-1).name = "error";


### PR DESCRIPTION
## Summary
- unify token and parameter config
- render params dynamically
- pass all params to `run()`

## Testing
- `npx prettier@3.5 --print-width=120 script.js README.md`
- `uvx ruff check --line-length 100 .`


------
https://chatgpt.com/codex/tasks/task_e_684a0ea9d0ac832c98d803294afcb042