### PR TITLE
Add GitLab API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ API Agent is an interactive web application that allows users to query APIs thro
 ## Features
 
 - **Natural Language Interface**: Ask questions in plain English to interact with APIs
-- **Multiple API Support**: Connect to GitHub, StackOverflow, Google Workspace, Jira, and more
+- **Multiple API Support**: Connect to GitHub, GitLab, StackOverflow, Google Workspace, Jira, and more
 - **Real-time Data**: Access up-to-date information from various platforms
 - **Code Generation**: Automatically generates and executes JavaScript code for API calls
 - **Result Validation**: Verifies that the results answer the original question
@@ -41,12 +41,18 @@ API Agent is an interactive web application that allows users to query APIs thro
 - Modern web browser (Chrome, Firefox, Safari, Edge)
 - API tokens (optional, but recommended for higher rate limits):
   - [GitHub Token](https://github.com/settings/tokens)
+  - [GitLab Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) and your [GitLab URL](https://docs.gitlab.com/ee/api/index.html#gitlab-api-endpoint-url) if self-hosted
   - [StackOverflow Token](https://stackapps.com/apps/oauth/register)
   - [Google OAuth Token](https://developers.google.com/oauthplayground/)
   - [Jira Token](https://id.atlassian.com/manage-profile/security/api-tokens)
   - [Google Custom Search API Key](https://developers.google.com/custom-search/v1/introduction)
   - [SerpApi Key](https://serpapi.com/manage-api-key)
   - [OpenRouter API Key](https://openrouter.ai/settings/keys)
+
+### GitLab API Usage
+
+The GitLab REST API lets you list projects, inspect issues and merge requests, and track activity.
+Use `/projects` to list repositories, `/projects/:id/repository/commits?since=<date>` to see recent commits, and `/users/:username/events` to view user actions.
 
 ### Local Setup
 

--- a/config.js
+++ b/config.js
@@ -23,6 +23,36 @@ export const demos = [
     ],
   },
   {
+    icon: "gitlab",
+    title: "GitLab API",
+    description: "Query GitLab projects, issues and merge requests.",
+    prompt:
+      "Use GitLab REST API at ${params.gitlabUrl}. If params.gitlabToken add Private-Token: ${params.gitlabToken}. List projects via /projects?membership=true. Track repo activity via /projects/:id/repository/commits?since=<ISO date> and user activity via /users/:user/events",
+    questions: [
+      "Show my GitLab projects",
+      "List commits in gitlab-org/gitlab since 2024-01-01",
+      "Merge requests updated today in my repo",
+      "Issues assigned to me",
+      "Events for user @root this week",
+    ],
+    params: [
+      {
+        label: "GitLab token",
+        link: "https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html",
+        required: false,
+        key: "gitlabToken",
+        type: "password",
+      },
+      {
+        label: "GitLab URL",
+        link: "https://docs.gitlab.com/ee/api/index.html#gitlab-api-endpoint-url",
+        required: false,
+        key: "gitlabUrl",
+        type: "text",
+      },
+    ],
+  },
+  {
     icon: "stack-overflow",
     title: "StackOverflow API",
     description: "Search questions, answers, and users on StackOverflow.",
@@ -393,8 +423,7 @@ Single entity responses return the object directly.
     icon: "h-circle",
     title: "HubSpot API",
     description: "Manage contacts and deals with HubSpot.",
-    prompt:
-      "Use HubSpot API. Send Authorization: Bearer ${params.hubspotToken}. hapikey=${params.hubspotClientId}",
+    prompt: "Use HubSpot API. Send Authorization: Bearer ${params.hubspotToken}. hapikey=${params.hubspotClientId}",
     questions: ["List contacts created last week", "Show total deals amount by stage"],
     params: [
       {


### PR DESCRIPTION
## Summary
- add GitLab API configuration after GitHub in config.js
- document GitLab token and URL in README
- mention common GitLab API usage

## Testing
- `npx -y prettier@3.5 --print-width=120 --write config.js README.md`
- `npx -y js-beautify@1 index.html --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`


------
https://chatgpt.com/codex/tasks/task_e_684e1b7dcdbc832c9a338dc8411514b2