### PR TITLE
Refactor API selection into sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     .hljs {
       padding: 1rem;
     }
+
   </style>
 </head>
 
@@ -25,6 +26,7 @@
   <nav class="navbar navbar-expand-lg bg-body-tertiary" data-bs-theme="dark">
     <div class="container-fluid">
       <a class="navbar-brand" href=".">API Agent</a>
+      <button class="btn btn-outline-light d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#api-offcanvas" aria-controls="api-offcanvas">APIs</button>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -44,135 +46,143 @@
   </nav>
 
   <div class="container-fluid">
-    <h1 class="display-1 my-4 text-center">API Agent</h1>
-    <h2 class="display-6 text-center">Chat with your APIs</h2>
-
-    <div class="mx-auto my-3 narrative">
-      <p>API agent let's you ask questions that can be answered by calling APIs. It's a simple way to get answers to questions that you can't find on the web.</p>
-      <p>With API Agent, you can:</p>
-      <ul>
-        <li><strong>Access real-time data</strong> from multiple sources without writing code</li>
-        <li><strong>Automate research tasks</strong> that would normally require manual API calls</li>
-        <li><strong>Integrate information</strong> across different platforms and services</li>
-      </ul>
-      <p>Business teams use API Agent to monitor competitors, track market trends, and gather intelligence without technical expertise. Developers use it to quickly prototype and test API interactions without writing boilerplate code.</p>
-    </div>
-
-    <!-- API Selection Cards -->
-    <div class="mx-auto my-4">
-      <div id="api-cards" class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-4 mb-4 justify-content-center">
-        <!-- API cards will be dynamically inserted here -->
-      </div>
-    </div>
-
-    <form id="task-form" class="narrative mx-auto">
-
-      <div class="my-4 p-4 card rounded-3 shadow-sm">
-        <h3 class="mb-3">Advanced Settings</h3>
-
-        <div class="accordion my-3" id="advancedSettings">
-          <!-- API Key Setting -->
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#apiKeyCollapse" aria-expanded="false" aria-controls="apiKeyCollapse">
-                <i class="bi bi-key me-2"></i>OpenAI API Key
-              </button>
-            </h2>
-            <div id="apiKeyCollapse" class="accordion-collapse collapse" data-bs-parent="#advancedSettings">
-              <div class="accordion-body">
-                <div class="mb-3">
-                  <label for="apiKeyInput" class="form-label">Enter your OpenAI API Key:</label>
-                  <input type="password" class="form-control" id="apiKeyInput" placeholder="sk-...">
-                  <div class="form-text">Your API key is stored locally in your browser and never sent to our servers.</div>
-                </div>
-              </div>
-            </div>
+    <div class="row">
+      <aside class="col-lg-3 p-0">
+        <div id="api-offcanvas" class="offcanvas-lg offcanvas-start show position-static border-end vh-100" data-bs-scroll="true" data-bs-backdrop="false" tabindex="-1">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title">APIs</h5>
+            <button class="btn-close d-lg-none" data-bs-dismiss="offcanvas"></button>
           </div>
-
-          <!-- Base URL Setting -->
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#baseUrlCollapse" aria-expanded="false" aria-controls="baseUrlCollapse">
-                <i class="bi bi-key me-2"></i>Base URL
-              </button>
-            </h2>
-            <div id="baseUrlCollapse" class="accordion-collapse collapse" data-bs-parent="#advancedSettings">
-              <div class="accordion-body">
-                <div class="mb-3">
-                  <label for="baseUrlInput" class="form-label">Enter your OpenAI API Base URL:</label>
-                  <input type="text" class="form-control" id="baseUrlInput" value="https://llmfoundry.straive.com/openai/v1" list="baseUrlList">
-                  <datalist id="baseUrlList">
-                    <option value="https://api.openai.com/v1"></option>
-                    <option value="https://llmfoundry.straive.com/openai/v1"></option>
-                    <option value="https://llmfoundry.straivedemo.com/openai/v1"></option>
-                    <option value="https://openrouter.ai/api/v1" disabled></option>
-                    <option value="https://aipipe.org/openai/v1" disabled></option>
-                  </datalist>
-                  <div class="form-text">Your API key is stored locally in your browser and never sent to our servers.</div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- System Prompt Setting -->
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#systemPromptCollapse" aria-expanded="false" aria-controls="systemPromptCollapse">
-                <i class="bi bi-chat-square-text me-2"></i>System Prompt &amp; Model
-              </button>
-            </h2>
-            <div id="systemPromptCollapse" class="accordion-collapse collapse" data-bs-parent="#advancedSettings">
-              <div class="accordion-body">
-                <div class="mb-3">
-                  <label for="system-prompt" class="form-label">Customize the system prompt:</label>
-                  <textarea class="form-control" id="system-prompt" rows="10"></textarea>
-                </div>
-                <div class="mb-3">
-                  <label for="model" class="form-label">Choose the model:</label>
-                  <input type="text" class="form-control" id="model" value="gpt-4.1-mini" list="modelList">
-                  <datalist id="modelList">
-                    <option value="gpt-4.1-nano"></option>
-                    <option value="gpt-4.1-mini"></option>
-                    <option value="gpt-4.1"></option>
-                    <option value="gpt-4o"></option>
-                    <option value="o4-mini"></option>
-                  </datalist>
-                </div>
-                <div class="mb-3">
-                  <label for="attempts" class="form-label">Number of retry attempts:</label>
-                  <input type="number" class="form-control" id="attempts" value="3">
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#tokenCollapse" aria-expanded="true" aria-controls="tokenCollapse">
-                <i class="bi bi-key me-2"></i>API Tokens
-              </button>
-            </h2>
-            <div id="tokenCollapse" class="accordion-collapse collapse show" data-bs-parent="#tokenAccordion">
-              <div class="accordion-body" id="token-inputs">
-                <!-- Token inputs will be dynamically inserted here -->
-              </div>
-            </div>
+          <div class="offcanvas-body overflow-auto p-0">
+            <div id="api-accordion" class="accordion"></div>
           </div>
         </div>
+      </aside>
+      <main class="col-lg-9">
+        <h1 class="display-1 my-4 text-center">API Agent</h1>
+        <h2 class="display-6 text-center">Chat with your APIs</h2>
 
-      </div>
+        <div class="mx-auto my-3 narrative">
+          <p>API agent let's you ask questions that can be answered by calling APIs. It's a simple way to get answers to questions that you can't find on the web.</p>
+          <p>With API Agent, you can:</p>
+          <ul>
+            <li><strong>Access real-time data</strong> from multiple sources without writing code</li>
+            <li><strong>Automate research tasks</strong> that would normally require manual API calls</li>
+            <li><strong>Integrate information</strong> across different platforms and services</li>
+          </ul>
+          <p>Business teams use API Agent to monitor competitors, track market trends, and gather intelligence without technical expertise. Developers use it to quickly prototype and test API interactions without writing boilerplate code.</p>
+        </div>
 
-      <h5 class="my-4 mb-3">Sample Questions:</h5>
-      <div id="example-questions" class="list-group my-4"></div>
+        <form id="task-form" class="narrative mx-auto">
 
-      <div id="results" class="mx-auto my-3 narrative"></div>
-      <div id="status" class="alert alert-info mx-auto my-3 narrative d-none" role="alert"></div>
+          <div class="my-4 p-4 card rounded-3 shadow-sm">
+            <h3 class="mb-3">Advanced Settings</h3>
 
-      <label for="question" class="form-label">Enter your question:</label>
-      <input type="text" class="form-control" name="question" id="question" placeholder="Ask a question">
-      <button type="submit" class="btn btn-primary mt-2">Submit</button>
-    </form>
+            <div class="accordion my-3" id="advancedSettings">
+              <!-- API Key Setting -->
+              <div class="accordion-item">
+                <h2 class="accordion-header">
+                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#apiKeyCollapse" aria-expanded="false" aria-controls="apiKeyCollapse">
+                    <i class="bi bi-key me-2"></i>OpenAI API Key
+                  </button>
+                </h2>
+                <div id="apiKeyCollapse" class="accordion-collapse collapse" data-bs-parent="#advancedSettings">
+                  <div class="accordion-body">
+                    <div class="mb-3">
+                      <label for="apiKeyInput" class="form-label">Enter your OpenAI API Key:</label>
+                      <input type="password" class="form-control" id="apiKeyInput" placeholder="sk-...">
+                      <div class="form-text">Your API key is stored locally in your browser and never sent to our servers.</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-    <footer style="height: 50vh"></footer>
+              <!-- Base URL Setting -->
+              <div class="accordion-item">
+                <h2 class="accordion-header">
+                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#baseUrlCollapse" aria-expanded="false" aria-controls="baseUrlCollapse">
+                    <i class="bi bi-key me-2"></i>Base URL
+                  </button>
+                </h2>
+                <div id="baseUrlCollapse" class="accordion-collapse collapse" data-bs-parent="#advancedSettings">
+                  <div class="accordion-body">
+                    <div class="mb-3">
+                      <label for="baseUrlInput" class="form-label">Enter your OpenAI API Base URL:</label>
+                      <input type="text" class="form-control" id="baseUrlInput" value="https://llmfoundry.straive.com/openai/v1" list="baseUrlList">
+                      <datalist id="baseUrlList">
+                        <option value="https://api.openai.com/v1"></option>
+                        <option value="https://llmfoundry.straive.com/openai/v1"></option>
+                        <option value="https://llmfoundry.straivedemo.com/openai/v1"></option>
+                        <option value="https://openrouter.ai/api/v1" disabled></option>
+                        <option value="https://aipipe.org/openai/v1" disabled></option>
+                      </datalist>
+                      <div class="form-text">Your API key is stored locally in your browser and never sent to our servers.</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- System Prompt Setting -->
+              <div class="accordion-item">
+                <h2 class="accordion-header">
+                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#systemPromptCollapse" aria-expanded="false" aria-controls="systemPromptCollapse">
+                    <i class="bi bi-chat-square-text me-2"></i>System Prompt &amp; Model
+                  </button>
+                </h2>
+                <div id="systemPromptCollapse" class="accordion-collapse collapse" data-bs-parent="#advancedSettings">
+                  <div class="accordion-body">
+                    <div class="mb-3">
+                      <label for="system-prompt" class="form-label">Customize the system prompt:</label>
+                      <textarea class="form-control" id="system-prompt" rows="10"></textarea>
+                    </div>
+                    <div class="mb-3">
+                      <label for="model" class="form-label">Choose the model:</label>
+                      <input type="text" class="form-control" id="model" value="gpt-4.1-mini" list="modelList">
+                      <datalist id="modelList">
+                        <option value="gpt-4.1-nano"></option>
+                        <option value="gpt-4.1-mini"></option>
+                        <option value="gpt-4.1"></option>
+                        <option value="gpt-4o"></option>
+                        <option value="o4-mini"></option>
+                      </datalist>
+                    </div>
+                    <div class="mb-3">
+                      <label for="attempts" class="form-label">Number of retry attempts:</label>
+                      <input type="number" class="form-control" id="attempts" value="3">
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="accordion-item">
+                <h2 class="accordion-header">
+                  <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#tokenCollapse" aria-expanded="true" aria-controls="tokenCollapse">
+                    <i class="bi bi-key me-2"></i>API Tokens
+                  </button>
+                </h2>
+                <div id="tokenCollapse" class="accordion-collapse collapse show" data-bs-parent="#tokenAccordion">
+                  <div class="accordion-body" id="token-inputs">
+                    <!-- Token inputs will be dynamically inserted here -->
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+
+          <h5 class="my-4 mb-3">Sample Questions:</h5>
+          <div id="example-questions" class="list-group my-4"></div>
+
+          <div id="results" class="mx-auto my-3 narrative"></div>
+          <div id="status" class="alert alert-info mx-auto my-3 narrative d-none" role="alert"></div>
+
+          <label for="question" class="form-label">Enter your question:</label>
+          <input type="text" class="form-control" name="question" id="question" placeholder="Ask a question">
+          <button type="submit" class="btn btn-primary mt-2">Submit</button>
+        </form>
+
+        <footer style="height: 50vh"></footer>
+      </main>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" type="module"></script>

--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ marked.use({
 const $taskForm = document.querySelector("#task-form");
 const $results = document.querySelector("#results");
 const $status = document.querySelector("#status");
-const $apiCards = document.querySelector("#api-cards");
+const $apiAccordion = document.querySelector("#api-accordion");
 const $exampleQuestions = document.querySelector("#example-questions");
 const $tokenInputs = document.querySelector("#token-inputs");
 const $systemPrompt = document.querySelector("#system-prompt");
@@ -34,49 +34,45 @@ const formState = saveform("#task-form", { exclude: '[type="file"]' });
 const messages = [];
 const selectedApis = new Set([0]);
 
-// Render API cards based on config
+// Render APIs inside accordion
 function renderApiCards() {
   render(
     demos.map(
-      (demo, index) => html`
-        <div class="col">
-          <div class="card h-100 api-card" data-index="${index}">
-            <div class="card-body text-center">
-              <i class="bi bi-${demo.icon} fs-1 mb-3"></i>
-              <h5 class="card-title">${demo.title}</h5>
-              <p class="card-text">${demo.description}</p>
-              <button class="btn btn-outline-primary select-api" data-index="${index}">Select</button>
+      (demo, i) => html`
+        <div class="accordion-item">
+          <h2 class="accordion-header">
+            <button class="accordion-button ${i ? 'collapsed' : ''}" type="button" data-bs-toggle="collapse" data-bs-target="#api-panel-${i}" aria-expanded="${!i}" aria-controls="api-panel-${i}">
+              <i class="bi bi-${demo.icon} me-2"></i>${demo.title}
+            </button>
+          </h2>
+          <div id="api-panel-${i}" class="accordion-collapse collapse ${!i ? 'show' : ''}" data-index="${i}">
+            <div class="accordion-body">
+              <p>${demo.description}</p>
             </div>
           </div>
         </div>
       `,
     ),
-    $apiCards,
+    $apiAccordion,
   );
 
-  // Add event listeners to API cards
-  document.querySelectorAll(".select-api").forEach((button) => {
-    button.addEventListener("click", (e) => {
-      const index = parseInt(e.target.dataset.index);
-      toggleApi(index);
-    });
+  $apiAccordion.querySelectorAll('.accordion-collapse').forEach((el) => {
+    el.addEventListener('shown.bs.collapse', () => updateSelection());
+    el.addEventListener('hidden.bs.collapse', () => updateSelection());
   });
 }
 
-// Toggle API selection and update the UI
-function toggleApi(index) {
-  if (selectedApis.has(index)) selectedApis.delete(index);
-  else selectedApis.add(index);
-  updateSelection();
-}
-
-function updateSelection() {
+function updateSelection(initial) {
+  selectedApis.clear();
+  $apiAccordion.querySelectorAll('.accordion-item').forEach((item, i) => {
+    const panel = item.querySelector('.accordion-collapse');
+    const btn = item.querySelector('.accordion-button');
+    const open = panel.classList.contains('show');
+    if (open) selectedApis.add(i);
+    btn.classList.toggle('bg-success', open && !(initial && i === 0));
+    btn.classList.toggle('text-white', open && !(initial && i === 0));
+  });
   const apis = [...selectedApis].map((i) => demos[i]);
-
-  document.querySelectorAll(".api-card").forEach((card, i) => {
-    if (selectedApis.has(i)) card.classList.add("border-primary", "shadow");
-    else card.classList.remove("border-primary", "shadow");
-  });
 
   render(
     apis
@@ -319,4 +315,4 @@ function renderSteps(steps) {
 
 // Initialize the application
 renderApiCards();
-updateSelection();
+updateSelection(true);


### PR DESCRIPTION
## WHY
- API cards clutter the main view
- Offcanvas improves navigation on mobile

## WHAT
- add responsive offcanvas sidebar with accordion APIs
- highlight active API panels
- update JS to sync sidebar state and sample data

## REVIEW
- layout changes in `index.html`
- accordion handling logic in `script.js`

## TEST
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `npx -y prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `uvx ruff --line-length 100` (no python files)

## RISKS
- layout regressions on small screens; verify sidebar collapses correctly

## LESSONS
- bootstrap offcanvas can be static sidebar with `offcanvas-lg show position-static`


------
https://chatgpt.com/codex/tasks/task_e_684fe5723a48832ca93246994fdc5420