### PR TITLE
Add Dropbox API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ API Agent is an interactive web application that allows users to query APIs thro
   - [Google Custom Search API Key](https://developers.google.com/custom-search/v1/introduction)
   - [SerpApi Key](https://serpapi.com/manage-api-key)
   - [OpenRouter API Key](https://openrouter.ai/settings/keys)
+  - [Dropbox Access Token](https://www.dropbox.com/developers/apps)
 
 ### GitLab API Usage
 

--- a/config.js
+++ b/config.js
@@ -441,6 +441,22 @@ Single entity responses return the object directly.
       },
     ],
   },
+  {
+    icon: "dropbox",
+    title: "Dropbox API",
+    description: "Manage files in your Dropbox account.",
+    prompt: "Use https://api.dropboxapi.com/2 with Authorization: Bearer ${params.dropbox}",
+    questions: ["List files in root", "Upload a demo.txt file", "Download /README.md"],
+    params: [
+      {
+        label: "Dropbox access token",
+        link: "https://www.dropbox.com/developers/apps",
+        required: true,
+        key: "dropbox",
+        type: "password",
+      },
+    ],
+  },
 ];
 
 // now() returns the current time to the nearest 10 minutes


### PR DESCRIPTION
## Summary
- include Dropbox API token instructions
- add Dropbox to the built-in API list

## Testing
- `npx -y prettier@3.5 --check --print-width=120 README.md config.js`
- `uvx ruff --line-length 100 || true`
- `npx -y js-beautify@1 index.html --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline && git checkout -- index.html`

------
https://chatgpt.com/codex/tasks/task_e_68515fe6bff8832c9d603818773c0a6a